### PR TITLE
CI: ensure a recent version of testinfra is installed before molecule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - MOLECULE_DISTRO: fedora27
 
 install:
-  - pip install molecule[docker]
+  - pip install testinfra molecule[docker]
 
 before_script:
   - cd ..


### PR DESCRIPTION
see https://github.com/ansible/molecule/issues/1727