### PR TITLE
Minor formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea/
 *.pyc
-
+**/pytestdebug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - MOLECULE_DISTRO: fedora27
 
 install:
-  - pip install testinfra molecule[docker]
+  - pip install testinfra==3.0.5 molecule[docker]==2.20.2
 
 before_script:
   - cd ..

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Role Variables
 --------------
 
 Required variables:
-```
+
+```yaml
 theo_url:
 theo_client_token:
 ```
@@ -30,12 +31,14 @@ None.
 Example Playbook
 ----------------
 
-    - hosts: servers
-      vars:
-        - theo_url: https://theo.example.com
-        - theo_client_token: zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP
-      roles:
-         - theoapp.theo_agent
+```yaml
+- hosts: servers
+  vars:
+    - theo_url: "https://theo.example.com"
+    - theo_client_token: "zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP"
+  roles:
+     - theoapp.theo_agent
+```
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,4 @@ theo_agent_cache_dir: /var/cache/theo-agent
 theo_agent_verify_signature: false
 theo_agent_public_key: ""
 theo_agent_public_key_path: "{{ theo_agent_config_dir }}/public.pem"
-theo_agent_sshd_authorized_keys_command: "{{ theo_agent_path }}"
+theo_agent_sshd_authorized_keys_command: "{{ theo_agent_path }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
     privileged: true
     pre_build_image: true
 provisioner:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,8 +2,8 @@
 - name: Converge
   hosts: all
   vars:
-    - theo_url: https://theo.example.com
-    - theo_client_token: zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP
+    - theo_url: "https://theo.example.com"
+    - theo_client_token: "zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP"
   pre_tasks:
     - name: Update apt cache
       apt:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,3 +1,4 @@
+"""Testinfra test for molecule"""
 import os
 
 import testinfra.utils.ansible_runner
@@ -20,16 +21,16 @@ def test_theo_config_file(host):
     assert f.group == 'root'
     conf = f.content
     '''
-    url: https://theo.example.com
+    url: "https://theo.example.com"
     token: \
-        zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP
+        "zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP"
     cachedir: /var/cache/theo-agent
     verify: False
     '''
     expected = [
-        b'url: https://theo.example.com',
-        b'token: zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp'
-        b'+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP',
+        b'url: "https://theo.example.com"',
+        b'token: "zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp'
+        b'+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP"',
         b'cachedir: /var/cache/theo-agent',
         b'verify: False'
     ]

--- a/molecule/signature/molecule.yml
+++ b/molecule/signature/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
     privileged: true
     pre_build_image: true
 provisioner:

--- a/molecule/signature/playbook.yml
+++ b/molecule/signature/playbook.yml
@@ -2,8 +2,8 @@
 - name: Converge
   hosts: all
   vars:
-    - theo_url: https://theo.example.com
-    - theo_client_token: zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP
+    - theo_url: "https://theo.example.com"
+    - theo_client_token: "zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP"
     - theo_agent_verify_signature: true
     - theo_agent_public_key: |
         -----BEGIN PUBLIC KEY-----

--- a/molecule/signature/tests/test_default.py
+++ b/molecule/signature/tests/test_default.py
@@ -20,17 +20,17 @@ def test_theo_config_file(host):
     assert f.group == 'root'
     conf = f.content
     '''
-    url: https://theo.example.com
+    url: "https://theo.example.com"
     token: \
-        zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP
+        "zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP"
     cachedir: /var/cache/theo-agent
     verify: True
     public_key: /etc/theo-agent/public.pem
     '''
     expected = [
-        b'url: https://theo.example.com',
-        b'token: zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp'
-        b'+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP',
+        b'url: "https://theo.example.com"',
+        b'token: "zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp'
+        b'+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP"',
         b'cachedir: /var/cache/theo-agent',
         b'verify: True',
         b'public_key: /etc/theo-agent/public.pem'

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -1,5 +1,7 @@
-url: {{ theo_url }}
-token: {{ theo_client_token }}
+---
+# {{ ansible_managed }}
+url: "{{ theo_url }}"
+token: "{{ theo_client_token }}"
 cachedir: {{ theo_agent_cache_dir }}
 verify: {{ theo_agent_verify_signature|capitalize }}
 {{ theo_agent_config_public_key_path }}

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -1,4 +1,3 @@
----
 # {{ ansible_managed }}
 url: "{{ theo_url }}"
 token: "{{ theo_client_token }}"


### PR DESCRIPTION
* use double quotes around yaml values (I've seen horrible nightmares because of wrong parsing of colons in yaml)
* escape double quotes in tests so they actually work
* add `ansible_managed` to template
* convert tabs to spaces in weird places
* ensure markdown files conform with markdownlint-cli