### PR TITLE
CI: molecule: remove distro ubuntu1404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - MOLECULE_DISTRO: debian8
     - MOLECULE_DISTRO: debian9
     - MOLECULE_DISTRO: debian10
-    - MOLECULE_DISTRO: ubuntu1404
     - MOLECULE_DISTRO: ubuntu1604
     - MOLECULE_DISTRO: ubuntu1804
     - MOLECULE_DISTRO: fedora27

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -53,7 +53,6 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
-        - trusty
         - xenial
     - name: EL
       versions:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -43,8 +43,6 @@ def test_sshd_config(host):
         expected = get_sshd_config_centos6()
     elif distro == 'debian8':
         expected = get_sshd_config_pre_v69()
-    elif distro == 'ubuntu1404':
-        expected = get_sshd_config_pre_v69()
     else:
         expected = get_sshd_config_v69()
     f = host.file('/etc/ssh/sshd_config')


### PR DESCRIPTION
Ubuntu 14.04 is EOL since april 2019