### PR TITLE
CI: stick with molecule 2.22 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - MOLECULE_DISTRO=fedora31
 
 install:
-  - pip install molecule[docker]
+  - pip install molecule[docker]==2.22
 
 before_script:
   - cd ..


### PR DESCRIPTION
Molecule >3.0 requires some porting: before we do that, stick with 2.22 to
avoid breaking the pipelines.

This one should bring the badge green until we port to molecule v3