### PR TITLE
Tasks: sshd: ansible_selinux is not always a bool

### DIFF
--- a/tasks/sshd.yml
+++ b/tasks/sshd.yml
@@ -56,4 +56,4 @@
   selinux_permissive:
     name: sshd_t
     permissive: true
-  when: ansible_selinux|bool
+  when: ansible_selinux is defined and ansible_selinux and ansible_selinux.status == 'enabled'


### PR DESCRIPTION
Checked on: debian/ubuntu/centos/fedora