### PR TITLE
CI: stick with version 4.2.2 for docker client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - MOLECULE_DISTRO=fedora32
 
 install:
-  - pip install molecule[docker]==2.22
+  - pip install molecule==2.22 docker==4.2.2
 
 before_script:
   - cd ..


### PR DESCRIPTION
workaround below incompatibility error between recent Python docker client and the version of the docker service provided by Travis.

docker.errors.APIError: 400 Client Error: Bad Request ("client version 1.39 is too new. Maximum supported API version is 1.38")