### PR TITLE
Revert "CI: stick with version 4.2.2 for docker client"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - MOLECULE_DISTRO=fedora32
 
 install:
-  - pip install molecule==2.22 docker==4.2.2
+  - pip install molecule[docker]==2.22
 
 before_script:
   - cd ..


### PR DESCRIPTION
This reverts commit dfdf82f7768465e5359a5b9af24888e1c0eb93cc.

This change is no more needed since docker-py 4.3.1 was released, which solved the
issue that popped up with 4.3.0 (see [1]).

[1] https://github.com/docker/docker-py/pull/2650