### PR TITLE
Temporarily Revert "meta: add fedora 33 to supported platforms"

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -63,7 +63,6 @@ galaxy_info:
       versions:
         - 31
         - 32
-        - 33
 
   # List tags for your role here, one per line. A tag is a keyword that describes
   # and categorizes the role. Users find roles by searching for tags. Be sure to


### PR DESCRIPTION
This reverts commit 53ae43d8fd52e15d8a6b69e32c74e13b3c56b634.

Due to Ansible Galaxy not yet listing Fedora 33 amongst supported platforms
(https://galaxy.ansible.com/api/v1/platforms/?name=Fedora) to avoid metadata
score drop, we temporarily remove Fedora 33 from galaxy metadata.

See https://github.com/ansible/galaxy/issues/2533