### PR TITLE
tasks: sshd: add support for setting UseDNS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,5 +9,6 @@ theo_agent_verify_signature: false
 theo_agent_public_key: ""
 theo_agent_public_key_path: "{{ theo_agent_config_dir }}/public.pem"
 theo_agent_sshd_authorized_keys_command: "{{ theo_agent_path }}"
+theo_agent_with_use_dns: false
 theo_agent_hostname_prefix: ""
 theo_agent_hostname_suffix: ""

--- a/tasks/sshd.yml
+++ b/tasks/sshd.yml
@@ -50,6 +50,9 @@
       line: "AuthorizedKeysCommand {{ theo_agent_sshd_authorized_keys_command }}"
     - regexp: "^AuthorizedKeysFile"
       line: "AuthorizedKeysFile {{ theo_agent_cache_dir }}/%u"
+    - regexp: "^UseDNS"
+      line: "UseDNS {{ 'yes' if theo_agent_with_use_dns else 'no' }}"
+
   notify: Restart sshd
 
 - name: Add sshd to the list of permissive domain on selinux


### PR DESCRIPTION
This commit adds the theo_agent_with_use_dns variable, to control whether the
UseDNS sshd config option is enabled or not. theo_agent_with_use_dns defaults
to false, which disables the option: this is sshd default behavior since
version 6.8p1.

Closes #59