### PR TITLE
Fix #44 2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ theo_agent_cache_dir: /var/cache/theo-agent
 theo_agent_verify_signature: false
 theo_agent_public_key: ""
 theo_agent_public_key_path: "{{ theo_agent_config_dir }}/public.pem"
+# theo_agent_sshd_authorized_keys_command: set this variable if you want a custom AuthorizedKeysCommand
+# NOTE: when theo_agent_sshd_authorized_keys_command is set theo_agent_path is ignored
 theo_agent_sshd_authorized_keys_command: ""
 theo_agent_with_use_dns: false
 theo_agent_hostname_prefix: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ theo_agent_cache_dir: /var/cache/theo-agent
 theo_agent_verify_signature: false
 theo_agent_public_key: ""
 theo_agent_public_key_path: "{{ theo_agent_config_dir }}/public.pem"
-theo_agent_sshd_authorized_keys_command: "{{ theo_agent_path }}"
+theo_agent_sshd_authorized_keys_command: ""
 theo_agent_with_use_dns: false
 theo_agent_hostname_prefix: ""
 theo_agent_hostname_suffix: ""

--- a/molecule/custom-authorized-keys-command/Dockerfile.j2
+++ b/molecule/custom-authorized-keys-command/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/molecule/custom-authorized-keys-command/INSTALL.rst
+++ b/molecule/custom-authorized-keys-command/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/custom-authorized-keys-command/converge.yml
+++ b/molecule/custom-authorized-keys-command/converge.yml
@@ -1,0 +1,48 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    - theo_url: https://theo.example.com
+    - theo_client_token: zdOPNza4jjtceH5F2rU0iOkIJ2xlV4hGUauKT4cNe8HAp+AMnzYEzSc0EIBGM+MJuqL7gLd6bwIP
+  pre_tasks:
+    - name: Wait for systemd to complete initialization.  # noqa 303
+      command: systemctl is-system-running
+      register: systemctl_status
+      until: >
+        'running' in systemctl_status.stdout or
+        'degraded' in systemctl_status.stdout
+      retries: 30
+      delay: 5
+      when: ansible_service_mgr == 'systemd'
+      changed_when: false
+      failed_when: systemctl_status.rc > 1
+      check_mode: no
+
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+        cache_valid_time: 600
+      when: ansible_os_family == 'Debian'
+
+    - name: Ensure sshd is installed
+      package:
+        name:
+          - openssh-server
+        state: present
+
+    - name: Ensure sshd service is started
+      service:
+        name: ssh
+        state: started
+      when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.04'
+
+    - name: Ensure sshd service is started
+      service:
+        name: sshd
+        state: started
+      when: not (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.04')
+
+  roles:
+    - role: ansible-theo-agent
+      vars:
+        theo_agent_sshd_authorized_keys_command: /custom/theo/agent/executable --with-custom-args

--- a/molecule/custom-authorized-keys-command/molecule.yml
+++ b/molecule/custom-authorized-keys-command/molecule.yml
@@ -1,0 +1,33 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: "${REGISTRY_USER:-geerlingguy}/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: testinfra
+scenario:
+  test_sequence:
+    - dependency
+    - lint
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - check
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/custom-authorized-keys-command/tests/conftest.py
+++ b/molecule/custom-authorized-keys-command/tests/conftest.py
@@ -1,0 +1,22 @@
+"""PyTest Fixtures."""
+from __future__ import absolute_import
+
+import os
+
+import pytest
+
+
+def pytest_runtest_setup(item):
+    """Run tests only when under molecule with testinfra installed."""
+    try:
+        import testinfra
+    except ImportError:
+        pytest.skip("Test requires testinfra", allow_module_level=True)
+    if "MOLECULE_INVENTORY_FILE" in os.environ:
+        pytest.testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+            os.environ["MOLECULE_INVENTORY_FILE"]
+        ).get_hosts("all")
+    else:
+        pytest.skip(
+            "Test should run only from inside molecule.", allow_module_level=True
+        )

--- a/molecule/custom-authorized-keys-command/tests/test_custom-authorized-keys-command.py
+++ b/molecule/custom-authorized-keys-command/tests/test_custom-authorized-keys-command.py
@@ -1,0 +1,28 @@
+"""Role testing files using testinfra."""
+
+
+def test_sshd_config(host):
+    expected = [
+        b'AuthorizedKeysCommand /custom/theo/agent/executable --with-custom-args',
+    ]
+    f = host.file('/etc/ssh/sshd_config')
+    config = f.content
+    configlines = []
+    for line in config.splitlines():
+        if not line.startswith(b'#'):
+            configlines.append(line)
+    '''
+        I don't want to use something like:
+            assert set(expected).issubset(configlines)
+        Because there's no detail of the missing line(s)
+    '''
+    errors = []
+    for line in expected:
+        if line not in configlines:
+            errors.append(line)
+
+    if(len(errors)):
+        print('Failed test_sshd_config, missing line(s)')
+        for error in errors:
+            print(error)
+        assert False

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -44,3 +44,6 @@
 
   roles:
     - role: ansible-theo-agent
+    - role: ansible-theo-agent
+      vars:
+        unused_var: "unused"

--- a/tasks/sshd.yml
+++ b/tasks/sshd.yml
@@ -6,20 +6,27 @@
       sshd_current_version is version('6.4', '>=')
     msg: With OpenSSH < 6.4 theo_agent_config_path must be /etc/theo-agent/config.yml
 
-- name: Set AuthorizedKeysCommand config snippet 1
-  set_fact:
-    theo_agent_sshd_authorized_keys_command: "{{ theo_agent_sshd_authorized_keys_command }} -config-file {{ theo_agent_config_path }}"
-  when: theo_agent_config_path != "/etc/theo-agent/config.yml" and sshd_current_version is version('6.4', '>')
+- name: Compute AuthorizedKeysCommand value
+  block:
+    - name: Initialize AuthorizedKeysCommand
+      set_fact:
+        theo_agent_sshd_authorized_keys_command_computed: "{{ theo_agent_path }}"
 
-- name: Set AuthorizedKeysCommand config snippet 2
-  set_fact:
-    theo_agent_sshd_authorized_keys_command: "{{ theo_agent_sshd_authorized_keys_command }} -fingerprint %f"
-  when: sshd_current_version is version('6.9', '>=')
+    - name: Set AuthorizedKeysCommand config snippet 1
+      set_fact:
+        theo_agent_sshd_authorized_keys_command_computed: "{{ theo_agent_sshd_authorized_keys_command_computed }} -config-file {{ theo_agent_config_path }}"
+      when: theo_agent_config_path != "/etc/theo-agent/config.yml" and sshd_current_version is version('6.4', '>')
 
-- name: Set AuthorizedKeysCommand config snippet 3
-  set_fact:
-    theo_agent_sshd_authorized_keys_command: "{{ theo_agent_sshd_authorized_keys_command }} %u"
-  when: theo_agent_sshd_authorized_keys_command != theo_agent_path
+    - name: Set AuthorizedKeysCommand config snippet 2
+      set_fact:
+        theo_agent_sshd_authorized_keys_command_computed: "{{ theo_agent_sshd_authorized_keys_command_computed }} -fingerprint %f"
+      when: sshd_current_version is version('6.9', '>=')
+
+    - name: Set AuthorizedKeysCommand config snippet 3
+      set_fact:
+        theo_agent_sshd_authorized_keys_command_computed: "{{ theo_agent_sshd_authorized_keys_command_computed }} %u"
+      when: theo_agent_sshd_authorized_keys_command_computed != theo_agent_path
+  when: theo_agent_sshd_authorized_keys_command|length == 0
 
 - name: Set AuthorizedKeysCommandUser config snippet
   set_fact:
@@ -47,7 +54,9 @@
       line: "PasswordAuthentication no"
     - "{{ sshd_authorized_keys_command_user_options }}"
     - regexp: "^AuthorizedKeysCommand "
-      line: "AuthorizedKeysCommand {{ theo_agent_sshd_authorized_keys_command }}"
+      line: >-
+        AuthorizedKeysCommand {{ theo_agent_sshd_authorized_keys_command if theo_agent_sshd_authorized_keys_command|length != 0
+        else theo_agent_sshd_authorized_keys_command_computed }}
     - regexp: "^AuthorizedKeysFile"
       line: "AuthorizedKeysFile {{ theo_agent_cache_dir }}/%u"
     - regexp: "^UseDNS"


### PR DESCRIPTION
This PR enhances #65 and #42 by preserving a user-configurable theo-agent command line via `theo_agent_sshd_authorized_keys_command`

Fixes #44